### PR TITLE
fix(kustomize): support builtin transformers

### DIFF
--- a/pkg/renderer/kustomize/kustomize_engine.go
+++ b/pkg/renderer/kustomize/kustomize_engine.go
@@ -38,7 +38,9 @@ func NewEngine(fs filesys.FileSystem, opts *RendererOptions) *Engine {
 	return &Engine{
 		kustomizer: krusty.MakeKustomizer(&krusty.Options{
 			LoadRestrictions: opts.LoadRestrictions,
-			PluginConfig:     &kustomizetypes.PluginConfig{},
+			PluginConfig: &kustomizetypes.PluginConfig{
+				BpLoadingOptions: kustomizetypes.BploUseStaticallyLinked,
+			},
 		}),
 		fs:   fs,
 		opts: opts,
@@ -55,7 +57,9 @@ func (e *Engine) Run(input Source, values map[string]string) ([]unstructured.Uns
 	// Create kustomizer with appropriate restrictions
 	kustomizer := krusty.MakeKustomizer(&krusty.Options{
 		LoadRestrictions: restrictions,
-		PluginConfig:     &kustomizetypes.PluginConfig{},
+		PluginConfig: &kustomizetypes.PluginConfig{
+			BpLoadingOptions: kustomizetypes.BploUseStaticallyLinked,
+		},
 	})
 
 	kust, name, err := readKustomization(e.fs, input.Path)

--- a/pkg/renderer/kustomize/kustomize_test.go
+++ b/pkg/renderer/kustomize/kustomize_test.go
@@ -177,6 +177,19 @@ resources:
 - configmap.yaml
 - deployment.yaml
 `
+const withTransformersKustomization = `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: test
+      namespace: test
+resources:
+- configmap.yaml
+`
 
 const annotationsBaseConfigMap = `
 apiVersion: v1
@@ -1122,4 +1135,31 @@ func TestLoadRestrictions(t *testing.T) {
 		g.Expect(err).Should(HaveOccurred())
 		g.Expect(err.Error()).Should(ContainSubstring("failed to run kustomize"))
 	})
+}
+
+func TestBuiltinTransformers(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "kustomization.yaml", withTransformersKustomization)
+	writeFile(t, dir, "configmap.yaml", basicConfigMap)
+
+	renderer, err := kustomize.New(
+		[]kustomize.Source{
+			{
+				Path: dir,
+				Values: kustomize.Values(map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				}),
+			},
+		},
+		kustomize.WithCache(),
+	)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objects, err := renderer.Process(t.Context(), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(objects).Should(HaveLen(1))
 }


### PR DESCRIPTION
Currently we get errors like:

```
unknown plugin loader behavior specified: NamespaceTransformer.builtin.[noGrp] BploUndefined
```